### PR TITLE
fix: add scraped event id to meetup

### DIFF
--- a/utils/eventScraper/webScraperMeetup.js
+++ b/utils/eventScraper/webScraperMeetup.js
@@ -59,9 +59,14 @@ const scrapeEvents = (userCountry, userCity, eventType) => new Promise((resolve,
     });
 
     for (let i = titlesArray.length - 1; i >= 0; i--) {
+      const link = linksArray[i];
+      const start = link.indexOf('ts/') + 3;
+      const newLink = link.substr(start, 9);
+
       dataSet.push({
         name: newTitles[i],
         eventDate: new Date(datesArray[i]),
+        scrapedEventId: newLink,
         scrapedEventLink: linksArray[i],
         location: locationsArray[i],
         source: 'meetup',


### PR DESCRIPTION
# Description
Scraped meetup events dont have ID, so i added it
## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
## Change status
- [x] Complete, but not tested (may need new tests)
# How Has This Been Tested?
Tests have been run on postman
# Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have run the app using my feature and ensured that no functionality is broken
- [x] My changes generate no new warnings
- [x] There are no merge conflicts